### PR TITLE
Add multiple execution contexts using sandboxes. Closes GH-5

### DIFF
--- a/app/main.html
+++ b/app/main.html
@@ -13,9 +13,10 @@
 <hr>
 <p><button id="clear">Clear</button>
 <div id="log"></div>
-<script src="bundle-main.js" charset="UTF-8"></script>
 <div id="sandboxes">
-<iframe id="sandbox-0" src="sandbox.html"></iframe>
+<!-- iframes will be created here -->
 </div>
+
+<script src="bundle-main.js" charset="UTF-8"></script>
 </body>
 </html>

--- a/app/main.js
+++ b/app/main.js
@@ -21,11 +21,12 @@ function newsb() {
 
   const iframe = document.createElement('iframe');
   iframe.setAttribute('id', 'sandbox-' + nextID);
-  nextID += 1;
   iframe.setAttribute('src', 'sandbox.html');
   container.appendChild(iframe);
 
-  iframe.contentWindow.postMessage({cmd: 'ping'});
+  iframe.contentWindow.postMessage({cmd: 'ping', sandbox_id: nextID}, '*');
+
+  nextID += 1;
 
   return iframe;
 }

--- a/app/main.js
+++ b/app/main.js
@@ -15,18 +15,18 @@ function evalsb(code) {
 }
 
 // Create a new sandboxed execution context: TODO: use only this, remove hardcoded sandbox-0
-let nextID = 1;
+let nextSbID = 1;
 function newsb() {
   const container = document.getElementById('sandboxes');
 
   const iframe = document.createElement('iframe');
-  iframe.setAttribute('id', 'sandbox-' + nextID);
+  iframe.setAttribute('id', 'sandbox-' + nextSbID);
   iframe.setAttribute('src', 'sandbox.html');
   container.appendChild(iframe);
 
-  iframe.contentWindow.postMessage({cmd: 'ping', sandbox_id: nextID}, '*');
+  iframe.contentWindow.postMessage({cmd: 'ping', sbID: nextSbID}, '*');
 
-  nextID += 1;
+  nextSbID += 1;
 
   return iframe;
 }

--- a/app/main.js
+++ b/app/main.js
@@ -14,19 +14,23 @@ function evalsb(code) {
   document.getElementById('sandbox-0').contentWindow.postMessage({cmd: 'eval', code: code}, '*');
 }
 
-// Create a new sandboxed execution context: TODO: use only this, remove hardcoded sandbox-0
-let nextSbID = 1;
+// Create a new sandboxed execution context
+let nextSbID = 0;
 function newsb() {
   const container = document.getElementById('sandboxes');
 
   const iframe = document.createElement('iframe');
-  iframe.setAttribute('id', 'sandbox-' + nextSbID);
-  iframe.setAttribute('src', 'sandbox.html');
-  container.appendChild(iframe);
-
-  iframe.contentWindow.postMessage({cmd: 'ping', sbID: nextSbID}, '*');
-
+  const sbID = nextSbID;
   nextSbID += 1;
+
+  iframe.setAttribute('id', 'sandbox-' + sbID);
+  iframe.setAttribute('src', 'sandbox.html');
+  iframe.addEventListener('load', (event) => {
+    console.log('sandbox frame load',sbID);
+    iframe.contentWindow.postMessage({cmd: 'ping', sbID: sbID}, '*');
+  });
+
+  container.appendChild(iframe);
 
   return iframe;
 }
@@ -39,3 +43,6 @@ function evalin(n, code) {
 }
 
 require('./send-native.js');
+
+console.log('creating initial sandbox');
+newsb(); // when page loads, create first sandbox

--- a/app/main.js
+++ b/app/main.js
@@ -1,48 +1,16 @@
 'use strict';
 
 require('./ui')(); // wire up button event handlers
+require('./send-native.js');
+
+const newsb = require('./multi').newsb;
+const evalin = require('./multi').evalin;
 
 // Expose globally for debugging
 Object.assign(global, {
-  evalsb: evalsb,
   newsb: newsb,
   evalin: evalin,
 });
-
-// Evaluate code in sandboxed frame
-function evalsb(code) {
-  document.getElementById('sandbox-0').contentWindow.postMessage({cmd: 'eval', code: code}, '*');
-}
-
-// Create a new sandboxed execution context
-let nextSbID = 0;
-function newsb() {
-  const container = document.getElementById('sandboxes');
-
-  const iframe = document.createElement('iframe');
-  const sbID = nextSbID;
-  nextSbID += 1;
-
-  iframe.setAttribute('id', 'sandbox-' + sbID);
-  iframe.setAttribute('src', 'sandbox.html');
-  iframe.addEventListener('load', (event) => {
-    console.log('sandbox frame load',sbID);
-    iframe.contentWindow.postMessage({cmd: 'ping', sbID: sbID}, '*');
-  });
-
-  container.appendChild(iframe);
-
-  return iframe;
-}
-
-function evalin(n, code) {
-  const iframe = document.getElementById('sandbox-' + n);
-  if (!iframe) throw new Error(`no such sandbox: ${n}`);
-
-  iframe.contentWindow.postMessage({cmd: 'eval', code: code}, '*');
-}
-
-require('./send-native.js');
 
 console.log('creating initial sandbox');
 newsb(); // when page loads, create first sandbox

--- a/app/multi.js
+++ b/app/multi.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// Multi-sandbox support
+// Maintains multiple independent execution contexts for JavaScript, using sandboxed iframes (unique origins)
+
+// Create a new sandboxed execution context
+let nextSbID = 0;
+function newsb() {
+  const container = document.getElementById('sandboxes');
+
+  const iframe = document.createElement('iframe');
+  const sbID = nextSbID;
+  nextSbID += 1;
+
+  iframe.setAttribute('id', 'sandbox-' + sbID);
+  iframe.setAttribute('src', 'sandbox.html');
+  iframe.addEventListener('load', (event) => {
+    console.log('sandbox frame load',sbID);
+    iframe.contentWindow.postMessage({cmd: 'ping', sbID: sbID}, '*');
+  });
+
+  container.appendChild(iframe);
+
+  return iframe;
+}
+
+// Evaluate code within a given sandbox
+function evalin(n, code) {
+  const iframe = document.getElementById('sandbox-' + n);
+  if (!iframe) throw new Error(`no such sandbox: ${n}`);
+
+  iframe.contentWindow.postMessage({cmd: 'eval', code: code}, '*');
+}
+
+// Send a message to the sandboxed iframe
+// TODO: track which sandbox sends us, send back instead of hardcoding sandbox-0
+function postSandbox(msg, sbID) {
+  const iframe = document.getElementById('sandbox-' + sbID); // TODO: maintain map of sbID -> iframes, populate in newsb(), instead of DOM lookup
+  const targetOrigin = '*';
+  iframe.contentWindow.postMessage(msg, targetOrigin);
+}
+
+
+module.exports = {
+  newsb,
+  evalin,
+  postSandbox,
+};

--- a/app/multi.js
+++ b/app/multi.js
@@ -3,14 +3,18 @@
 // Multi-sandbox support
 // Maintains multiple independent execution contexts for JavaScript, using sandboxed iframes (unique origins)
 
-// Create a new sandboxed execution context
 let nextSbID = 0;
+let iframes = new Map();
+
+// Create a new sandboxed execution context
 function newsb() {
   const container = document.getElementById('sandboxes');
 
   const iframe = document.createElement('iframe');
   const sbID = nextSbID;
   nextSbID += 1;
+
+  iframes.set(sbID, iframe);
 
   iframe.setAttribute('id', 'sandbox-' + sbID);
   iframe.setAttribute('src', 'sandbox.html');
@@ -24,20 +28,17 @@ function newsb() {
   return iframe;
 }
 
-// Evaluate code within a given sandbox
-function evalin(n, code) {
-  const iframe = document.getElementById('sandbox-' + n);
-  if (!iframe) throw new Error(`no such sandbox: ${n}`);
+// Send a message to the sandboxed iframe
+function postSandbox(sbID, msg) {
+  const iframe = iframes.get(sbID);
+  if (!iframe) throw new Error(`no such sandbox: ${sbID}`);
 
-  iframe.contentWindow.postMessage({cmd: 'eval', code: code}, '*');
+  iframe.contentWindow.postMessage(msg, '*');
 }
 
-// Send a message to the sandboxed iframe
-// TODO: track which sandbox sends us, send back instead of hardcoding sandbox-0
-function postSandbox(msg, sbID) {
-  const iframe = document.getElementById('sandbox-' + sbID); // TODO: maintain map of sbID -> iframes, populate in newsb(), instead of DOM lookup
-  const targetOrigin = '*';
-  iframe.contentWindow.postMessage(msg, targetOrigin);
+// Evaluate code within a given sandbox
+function evalin(sbID, code) {
+  postSandbox(sbID, {cmd: 'eval', code: code});
 }
 
 

--- a/app/prelude2.js
+++ b/app/prelude2.js
@@ -36,7 +36,8 @@
             };
             // https://github.com/deathcap/webnpm/issues/5 Implement require.resolve
             R.resolve = (module) => {
-                console.log('require.resolve', module);
+                // TODO: actually resolve, https://www.npmjs.com/package/require-resolve
+                //console.log('require.resolve', module);
                 return module;
             };
             modules[name][0].call(m.exports, R

--- a/app/send-native-proxy.js
+++ b/app/send-native-proxy.js
@@ -9,6 +9,8 @@ let nextID = 1;
 let mainSource = null;
 let mainOrigin = null;
 
+let ourSandboxID = null;
+
 window.addEventListener('message', (event) => {
   if (event.data.cmd === 'ping') {
     event.source.postMessage({pong: true}, event.origin);
@@ -16,6 +18,7 @@ window.addEventListener('message', (event) => {
     // save for sending messages back to main thread later
     mainSource = event.source;
     mainOrigin = event.origin;
+    ourSandboxID = event.data.sandbox_id;
     console.log('sandbox received ping:',event.data);
   } else if (event.data.cmd === 'recvNative') {
     //console.log('recvNative in sandbox', event.data);
@@ -49,6 +52,7 @@ function proxiedSendNative(method, params, cb) {
   nextID += 1;
 
   // To main thread
+  // TODO: send ourSandboxID
   mainSource.postMessage({cmd: 'sendNative', method, params, id}, mainOrigin);
 
   callbacks.set(id, (response) => decodeResponse(response, cb));

--- a/app/send-native-proxy.js
+++ b/app/send-native-proxy.js
@@ -9,17 +9,17 @@ let nextID = 1;
 let mainSource = null;
 let mainOrigin = null;
 
-let ourSandboxID = null;
+let sbID = null; // our sandbox identifier, who we are TODO: global, 'in sandbox' info on process. like process id (pid)
 
 window.addEventListener('message', (event) => {
   if (event.data.cmd === 'ping') {
-    event.source.postMessage({pong: true}, event.origin);
-
     // save for sending messages back to main thread later
     mainSource = event.source;
     mainOrigin = event.origin;
-    ourSandboxID = event.data.sandbox_id;
+    sbID = event.data.sbID;
     console.log('sandbox received ping:',event.data);
+
+    event.source.postMessage({pong: true, sbID: event.data.sbID}, event.origin);
   } else if (event.data.cmd === 'recvNative') {
     //console.log('recvNative in sandbox', event.data);
     handleIncoming(event.data.msg);
@@ -52,8 +52,7 @@ function proxiedSendNative(method, params, cb) {
   nextID += 1;
 
   // To main thread
-  // TODO: send ourSandboxID
-  mainSource.postMessage({cmd: 'sendNative', method, params, msgID}, mainOrigin);
+  mainSource.postMessage({cmd: 'sendNative', method, params, msgID, sbID}, mainOrigin);
 
   callbacks.set(msgID, (response) => decodeResponse(response, cb));
 };

--- a/app/send-native-proxy.js
+++ b/app/send-native-proxy.js
@@ -27,13 +27,13 @@ window.addEventListener('message', (event) => {
 });
 
 function handleIncoming(msg) {
-  const cb = callbacks.get(msg.id);
+  const cb = callbacks.get(msg.msgID);
   if (!cb) {
-    throw new Error(`received native host message with unexpected id: ${msg.id} in ${JSON.stringify(msg)}`);
+    throw new Error(`received native host message with unexpected id: ${msg.msgID} in ${JSON.stringify(msg)}`);
   }
 
   cb(msg);
-  callbacks.delete(msg.id);
+  callbacks.delete(msg.msgID);
 }
 
 function decodeResponse(response, cb) {
@@ -48,14 +48,14 @@ function decodeResponse(response, cb) {
 
 function proxiedSendNative(method, params, cb) {
   //console.log('proxiedSendNative',method,params);
-  const id = nextID;
+  const msgID = nextID;
   nextID += 1;
 
   // To main thread
   // TODO: send ourSandboxID
-  mainSource.postMessage({cmd: 'sendNative', method, params, id}, mainOrigin);
+  mainSource.postMessage({cmd: 'sendNative', method, params, msgID}, mainOrigin);
 
-  callbacks.set(id, (response) => decodeResponse(response, cb));
+  callbacks.set(msgID, (response) => decodeResponse(response, cb));
 };
 
 module.exports = proxiedSendNative;

--- a/app/send-native.js
+++ b/app/send-native.js
@@ -62,13 +62,6 @@ function sendNative(method, params, msgID, sbID) {
   //chrome.runtime.sendNativeMessage(application, msg, (response) => decodeResponse(response, cb));
 }
 
-// When the page loads, first contact the sandbox frame so it gets our event source
-// TODO: refactor with newsb()
-window.addEventListener('load', (event) => {
-  console.log('onload');
-  postSandbox({cmd: 'ping', sbID: 0}, 0);
-});
-
 window.addEventListener('message', (event) => {
   //console.log('received sandbox iframe message:',event);
   //console.log('main event data:',event.data);

--- a/app/send-native.js
+++ b/app/send-native.js
@@ -66,7 +66,7 @@ function sendNative(method, params, id) {
 // TODO: refactor with newsb()
 window.addEventListener('load', (event) => {
   console.log('onload');
-  postSandbox({cmd: 'ping'});
+  postSandbox({cmd: 'ping', sandbox_id: 0});
 });
 
 window.addEventListener('message', (event) => {

--- a/app/send-native.js
+++ b/app/send-native.js
@@ -6,8 +6,8 @@ let port = null;
 
 // Send a message to the sandboxed iframe
 // TODO: track which sandbox sends us, send back instead of hardcoding sandbox-0
-function postSandbox(msg) {
-  const iframe = document.getElementById('sandbox-0');
+function postSandbox(msg, sbID) {
+  const iframe = document.getElementById('sandbox-' + sbID); // TODO: maintain map of sbID -> iframes, populate in newsb(), instead of DOM lookup
   const targetOrigin = '*';
   iframe.contentWindow.postMessage(msg, targetOrigin);
 }
@@ -20,7 +20,7 @@ function disconnected(e) {
 
 function recvIncoming(msg) {
   //console.log('received incoming native msg:',msg);
-  postSandbox({cmd: 'recvNative', msg: msg});
+  postSandbox({cmd: 'recvNative', msg: msg}, msg.sbID);
 }
 
 function connectPort() {
@@ -66,7 +66,7 @@ function sendNative(method, params, msgID, sbID) {
 // TODO: refactor with newsb()
 window.addEventListener('load', (event) => {
   console.log('onload');
-  postSandbox({cmd: 'ping', sbID: 0});
+  postSandbox({cmd: 'ping', sbID: 0}, 0);
 });
 
 window.addEventListener('message', (event) => {

--- a/app/send-native.js
+++ b/app/send-native.js
@@ -32,7 +32,7 @@ function connectPort() {
 }
 
 // Send message using Google Chrome Native Messaging API to a native code host
-function sendNative(method, params, id) {
+function sendNative(method, params, msgID) {
 
   const paramsEncoded = [];
   for (let i = 0; i < params.length; ++i) {
@@ -47,7 +47,7 @@ function sendNative(method, params, id) {
     paramsEncoded.push(param);
   }
 
-  const msg = {method, params: paramsEncoded, id};
+  const msg = {method, params: paramsEncoded, msgID};
 
   console.log('sendNative',msg);
 
@@ -77,7 +77,7 @@ window.addEventListener('message', (event) => {
   // Main thread receives sendNative messages from sandbox -> sends them to native host
   if (event.data.cmd === 'sendNative') {
     //console.log('received main thread sendNative event:',event);
-    sendNative(event.data.method, event.data.params, event.data.id);
+    sendNative(event.data.method, event.data.params, event.data.msgID);
   }
 });
 

--- a/app/send-native.js
+++ b/app/send-native.js
@@ -32,7 +32,7 @@ function connectPort() {
 }
 
 // Send message using Google Chrome Native Messaging API to a native code host
-function sendNative(method, params, msgID) {
+function sendNative(method, params, msgID, sbID) {
 
   const paramsEncoded = [];
   for (let i = 0; i < params.length; ++i) {
@@ -47,7 +47,7 @@ function sendNative(method, params, msgID) {
     paramsEncoded.push(param);
   }
 
-  const msg = {method, params: paramsEncoded, msgID};
+  const msg = {method, params: paramsEncoded, msgID, sbID};
 
   console.log('sendNative',msg);
 
@@ -66,7 +66,7 @@ function sendNative(method, params, msgID) {
 // TODO: refactor with newsb()
 window.addEventListener('load', (event) => {
   console.log('onload');
-  postSandbox({cmd: 'ping', sandbox_id: 0});
+  postSandbox({cmd: 'ping', sbID: 0});
 });
 
 window.addEventListener('message', (event) => {
@@ -77,7 +77,8 @@ window.addEventListener('message', (event) => {
   // Main thread receives sendNative messages from sandbox -> sends them to native host
   if (event.data.cmd === 'sendNative') {
     //console.log('received main thread sendNative event:',event);
-    sendNative(event.data.method, event.data.params, event.data.msgID);
+    const sbID = event.data.sbID; // TODO: get sbID from resolving event.origin instead of trusting sandbox to say who it is? if it matters
+    sendNative(event.data.method, event.data.params, event.data.msgID, sbID);
   }
 });
 

--- a/app/send-native.js
+++ b/app/send-native.js
@@ -14,7 +14,7 @@ function disconnected(e) {
 
 function recvIncoming(msg) {
   //console.log('received incoming native msg:',msg);
-  postSandbox({cmd: 'recvNative', msg: msg}, msg.sbID);
+  postSandbox(msg.sbID, {cmd: 'recvNative', msg: msg});
 }
 
 function connectPort() {

--- a/app/send-native.js
+++ b/app/send-native.js
@@ -1,16 +1,10 @@
 'use strict';
 
+const postSandbox = require('./multi').postSandbox;
+
 const application = 'io.github.deathcap.nodeachrome';
 
 let port = null;
-
-// Send a message to the sandboxed iframe
-// TODO: track which sandbox sends us, send back instead of hardcoding sandbox-0
-function postSandbox(msg, sbID) {
-  const iframe = document.getElementById('sandbox-' + sbID); // TODO: maintain map of sbID -> iframes, populate in newsb(), instead of DOM lookup
-  const targetOrigin = '*';
-  iframe.contentWindow.postMessage(msg, targetOrigin);
-}
 
 function disconnected(e) {
   port = null; // to allow to reconnect if it crashes

--- a/host/host.js
+++ b/host/host.js
@@ -52,29 +52,29 @@ process.stdin
   .pipe(output)
   .pipe(process.stdout);
 
-function encodeResult(err, data, id) {
+function encodeResult(err, data, msgID) {
   if (err) {
     return {error:
              {
                code: err.errno, // must be an integer, but err.code is a string like 'ENOENT'
                message: err.toString(),
              },
-             id: id,
+             msgID: msgID,
            };
   } else {
-    return {result:data, id:id};
+    return {result:data, msgID:msgID};
   }
 }
 
 function messageHandler(msg, push, done) {
   const method = msg.method;
   const params = msg.params;
-  const id = msg.id;
+  const msgID = msg.msgID;
 
   console.error('received',msg);
 
   function cb(err, data) {
-    const response = encodeResult(err, data, id);
+    const response = encodeResult(err, data, msgID);
     console.error('sending',response);
     push(response);
     done();
@@ -239,7 +239,7 @@ function messageHandler(msg, push, done) {
       push({
         result: bytesRead,
         outBuffer: outBuffer,
-        id: id
+        msgID: msgID,
       });
       done();
     });
@@ -248,7 +248,7 @@ function messageHandler(msg, push, done) {
       code: -32601, // defined in http://www.jsonrpc.org/specification#response_object
       message: 'Method not found',
       data: `invalid method: ${method}`,
-      id: id,
+      msgID: msgID,
     }});
     done();
   }

--- a/host/host.js
+++ b/host/host.js
@@ -52,17 +52,18 @@ process.stdin
   .pipe(output)
   .pipe(process.stdout);
 
-function encodeResult(err, data, msgID) {
+function encodeResult(err, data, msgID, sbID) {
   if (err) {
     return {error:
              {
                code: err.errno, // must be an integer, but err.code is a string like 'ENOENT'
                message: err.toString(),
              },
-             msgID: msgID,
+             msgID,
+             sbID,
            };
   } else {
-    return {result:data, msgID:msgID};
+    return {result: data, msgID, sbID};
   }
 }
 
@@ -70,11 +71,12 @@ function messageHandler(msg, push, done) {
   const method = msg.method;
   const params = msg.params;
   const msgID = msg.msgID;
+  const sbID = msg.sbID;
 
   console.error('received',msg);
 
   function cb(err, data) {
-    const response = encodeResult(err, data, msgID);
+    const response = encodeResult(err, data, msgID, sbID);
     console.error('sending',response);
     push(response);
     done();
@@ -239,7 +241,8 @@ function messageHandler(msg, push, done) {
       push({
         result: bytesRead,
         outBuffer: outBuffer,
-        msgID: msgID,
+        msgID,
+        sbID,
       });
       done();
     });
@@ -248,7 +251,8 @@ function messageHandler(msg, push, done) {
       code: -32601, // defined in http://www.jsonrpc.org/specification#response_object
       message: 'Method not found',
       data: `invalid method: ${method}`,
-      msgID: msgID,
+      msgID,
+      sbID,
     }});
     done();
   }


### PR DESCRIPTION
https://github.com/deathcap/nodeachrome/issues/5 ""Callback called more than once."" - solved using a clean sandbox for each invocation, just like command-line utilities expect, example:

``` javascript
evalin(0, "npm_cli(['/bin/node', 'npm', 'substack'])")
newsb()
evalin(1, "npm_cli(['/bin/node', 'npm', 'substack'])")
newsb()
evalin(2, "npm_cli(['/bin/node', 'npm', 'substack'])")
```
