### PR TITLE
Secure the IPC messaging by using event.source instead of passing and trusting process.pid. Closes GH-18

### DIFF
--- a/app/kernel/kernel.js
+++ b/app/kernel/kernel.js
@@ -7,7 +7,6 @@ require('./kfetch.js');
 
 const Process = require('./scheduler').Process;
 const evalin = require('./scheduler').evalin;
-const kill = require('./scheduler').kill;
 
 // Globally default environment variables, set here since processes inherit them
 const ENV = {
@@ -25,7 +24,6 @@ Object.assign(global, {
   Process: Process,
 
   evalin: evalin,
-  kill: kill,
   ENV: ENV,
 });
 

--- a/app/kernel/kernel.js
+++ b/app/kernel/kernel.js
@@ -5,7 +5,7 @@
 require('./native.js');
 require('./kfetch.js');
 
-const spawn = require('./scheduler').spawn;
+const Process = require('./scheduler').Process;
 const evalin = require('./scheduler').evalin;
 const kill = require('./scheduler').kill;
 
@@ -22,11 +22,13 @@ const ENV = {
 
 // Expose globally for debugging
 Object.assign(global, {
-  spawn: spawn,
+  Process: Process,
+
   evalin: evalin,
   kill: kill,
   ENV: ENV,
 });
 
-console.log('creating initial sandbox');
-spawn(['init']); // when page loads, create first sandbox
+console.log('creating initial process');
+const init = new Process();
+init.exec(['init']);

--- a/app/kernel/kfetch.js
+++ b/app/kernel/kfetch.js
@@ -10,7 +10,10 @@ window.addEventListener('message', (event) => {
     console.log('got fetch',event.data);
 
     const id = event.data.id;
-    const pid = event.data.pid;
+
+    function reply(msg) {
+      event.source.postMessage(msg, '*');
+    }
 
     if (event.data.method === 'fetch') {
       function resolve(dataObject) {
@@ -26,24 +29,24 @@ window.addEventListener('message', (event) => {
           url: dataObject.url,
           headers: JSON.parse(JSON.stringify(dataObject.headers)), // https://fetch.spec.whatwg.org/#headers-class
         };
-        postUserland(pid, {cmd: 'fetch', method: 'resolve', id, data});
+        reply( {cmd: 'fetch', method: 'resolve', id, data});
 
         const reader = dataObject.body.getReader();
         function read() {
           reader.read().then((result) => {
-            postUserland(pid, {cmd: 'fetch', method: 'resolveRead', id, result});
+            reply({cmd: 'fetch', method: 'resolveRead', id, result});
             if (!result.done) {
               read();
             }
           }).catch((err) => {
-            postUserland(pid, {cmd: 'fetch', method: 'rejectRead', id, err});
+            reply({cmd: 'fetch', method: 'rejectRead', id, err});
           });
         }
         read();
       }
       function reject(err) {
         err = err.toString(); // TODO: fix cloning
-        postUserland(pid, {cmd: 'fetch', method: 'reject', id, err});
+        reply({cmd: 'fetch', method: 'reject', id, err});
       }
 
       const request = fetch(event.data.input, event.data.init).then(resolve).catch(reject);

--- a/app/kernel/scheduler.js
+++ b/app/kernel/scheduler.js
@@ -8,6 +8,53 @@ let iframes = new Map();
 
 const {createDraggableIframe} = require('./windowing');
 
+class Process {
+  constructor() {
+    this.state = 'new'; // see https://en.wikipedia.org/wiki/Process_state
+    this.pid = nextPid;
+    nextPid += 1;
+
+    let {iframe, container} = createDraggableIframe(pid);
+
+    this.iframe = iframe;
+    this.container = container;
+
+    iframes.set(pid, iframe);
+
+    const containers = document.getElementById('userland-processes');
+    containers.appendChild(container);
+
+    console.log(`new Process: pid=${this.pid}`);
+    // process is created in frozen state, can be started with exec()
+  }
+
+  exec(argv, env) {
+    if (!env) env = global.ENV; // inherit from kernel TODO: per-process inheritance, forking
+
+    this.state = 'waiting'; // awaiting execution
+    iframe.setAttribute('src', '/userland/userland.html');
+    iframe.addEventListener('load', (event) => {
+      console.log('sandbox frame load',pid);
+      iframe.contentWindow.postMessage({cmd: '_start', pid: pid, argv, env}, '*');
+      this.state = 'running'; // TODO: or should differentiate between frame loaded, and confirmed the frame is running the script? get feedback from _start
+    });
+  }
+
+  postMessage(msg) {
+    if (!this.iframe.contentWindow) throw new Error(`no such process, terminated: ${this.pid}`);
+
+    this.iframe.contentWindow.postMessage(msg, '*');
+  }
+
+  terminate() {
+    this.iframe.parentNode.removeChild(iframe); // TODO: remove container???
+    this.iframes.delete(pid);
+    console.log(`Terminated ${pid}`);
+    this.state = 'terminated';
+    // TODO: reap zombies
+  }
+}
+
 // Create a new "userland" sandboxed execution context, previously 'newsb',
 // like Unix spawn/exec (close enough) or posix_spawn/system
 // TODO: Unix-ish standard Node API to implement instead? process, os? exec? Found it: https://nodejs.org/api/child_process.html exec!

--- a/app/kernel/scheduler.js
+++ b/app/kernel/scheduler.js
@@ -57,9 +57,9 @@ class Process {
   }
 
   terminate() {
-    this.iframe.parentNode.removeChild(iframe); // TODO: remove container???
-    this.iframes.delete(pid);
-    console.log(`Terminated ${pid}`);
+    this.container.parentNode.removeChild(this.container);
+    processes.delete(this.pid);
+    console.log(`Terminated ${this.pid}`);
     this.state = 'terminated';
     // TODO: reap zombies
   }
@@ -82,21 +82,8 @@ function evalin(pid, code) {
   postUserland(pid, {cmd: 'eval', code: code});
 }
 
-function kill(pid, signal) {
-  //TODO: SIGTERM etc. postUserland(pid, {cmd: 'signal', signal: signal});
-  //if (signal === 'SIGKILL') {
-  
-    const iframe = iframes.get(pid);
-    iframe.parentNode.removeChild(iframe);
-    iframes.delete(pid);
-    console.log(`Killed ${pid}`);
-
-  //}
-}
-
 module.exports = {
   Process,
   evalin,
   postUserland,
-  kill,
 };

--- a/app/userland/fetch.js
+++ b/app/userland/fetch.js
@@ -15,7 +15,7 @@ let id2rejectRead = new Map();
 global.fetch = function(input, init) {
   return new Promise((resolve, reject) => {
     const id = nextID;
-    syscall({cmd: 'fetch', method: 'fetch', id, pid: process.pid, input, init});
+    syscall({cmd: 'fetch', method: 'fetch', id, input, init});
     nextID += 1;
 
     id2resolve.set(id, resolve);

--- a/app/userland/syscall.js
+++ b/app/userland/syscall.js
@@ -24,7 +24,7 @@ window.addEventListener('message', (event) => {
     console.log('sandbox received _start:',event.data);
     process.stdout.write(`\nStarted pid=${process.pid}, argv=${JSON.stringify(process.argv)}, env=${JSON.stringify(process.env)}\n`);
 
-    event.source.postMessage({cmd: 'started', token: event.data.token}, event.origin);
+    event.source.postMessage({cmd: 'started'}, event.origin);
   }
 });
 

--- a/app/userland/syscall.js
+++ b/app/userland/syscall.js
@@ -24,7 +24,7 @@ window.addEventListener('message', (event) => {
     console.log('sandbox received _start:',event.data);
     process.stdout.write(`\nStarted pid=${process.pid}, argv=${JSON.stringify(process.argv)}, env=${JSON.stringify(process.env)}\n`);
 
-    event.source.postMessage({pong: true, pid: event.data.pid}, event.origin);
+    event.source.postMessage({cmd: 'started', token: event.data.token}, event.origin);
   }
 });
 


### PR DESCRIPTION
Closes https://github.com/deathcap/nodeachrome/issues/18
