### PR TITLE
Add Unix cli.js client for command-line native usage. Closes GH-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,23 @@ registry client to function, example:
 * require.resolve(x) returns x, modified browserify prelude in prelude2.js
 
 
-## tools
+## bin
 
-Bundled tools intended to run under this project: (note: may be broken)
+Bundled programs intended to run under this project: (note: may be broken)
 
 * [browserify](http://browserify.org) API (example: `browserify('foo.js').bundle().pipe(process.stdout)`)
 * [npm](https://www.npmjs.com) API
+
+See `app/userland/bin` for all included. 
+
+When Nodeachrome is running, it can be interacted with on the Unix command-line using `cli.js`, for example:
+
+```shell
+./host/cli.js -e '3+4'
+./host/cli.js npm view ucfirst
+```
+
+Each call spawns a new process and runs the command-line program.
 
 ## License
 

--- a/app/kernel/native.js
+++ b/app/kernel/native.js
@@ -3,6 +3,7 @@
 // Chrome platform API to native messaging host
 
 const postUserland = require('./scheduler').postUserland;
+const Process = require('./scheduler').Process;
 
 const application = 'io.github.deathcap.nodeachrome';
 
@@ -16,6 +17,11 @@ function disconnected(e) {
 
 function recvIncoming(msg) {
   //console.log('received incoming native msg:',msg);
+  if (msg.fromUnix) { // unsolicited request from Unix, not a reply
+    new Process().exec(msg.args);
+    return;
+  }
+
   postUserland(msg.pid, {cmd: 'recvNative', msg: msg});
 }
 

--- a/app/userland/bin/eval.js
+++ b/app/userland/bin/eval.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Evaluate the JavaScript code passed on command-line
+
+if (process.argv.length <= 2) {
+  process.stderr.write(`usage: ${process.argv[1]} code\n`);
+  process.exit(1);
+}
+
+const code = process.argv[2];
+
+process.stdout.write(`evaluating: ${code}\n`);
+
+const result = eval(code);
+
+process.stdout.write(`result: ${JSON.stringify(result, null, '  ')}\n`);
+//console.log(result);

--- a/app/userland/bin/init.js
+++ b/app/userland/bin/init.js
@@ -1,5 +1,9 @@
 'use strict';
 
-process.stdout.write('init started');
+const fs = require('fs');
 
+process.stdout.write('init starting\n');
 
+fs._ping(() => {
+  process.stdout.write('native host up\n');
+});

--- a/app/userland/fs.js
+++ b/app/userland/fs.js
@@ -12,6 +12,11 @@ const sendNative = require('./native-proxy'); // in sandbox
 
 const fs = {};
 
+// not a filesystem operation, but makes sure the native host is up (otherwise a no-op)
+fs._ping = (cb) => {
+  sendNative('fs._ping', [], cb);
+};
+
 fs.access = (path, mode, cb) => {
   if (!cb) {
     cb = mode;

--- a/app/userland/syscall.js
+++ b/app/userland/syscall.js
@@ -34,6 +34,7 @@ window.addEventListener('message', (event) => {
       npm: () => require('./bin/npm'),
       browserify: () => require('./bin/browserify'),
       ls: () => require('./bin/ls'),
+      eval: () => require('./bin/eval'),
     };
 
     if (commands[process.argv[1]]) {

--- a/host/cli.js
+++ b/host/cli.js
@@ -7,13 +7,22 @@ const net = require('net');
 const path = require('path');
 const nativeMessage = require('chrome-native-messaging');
 
-const SOCKET_PATH = path.join(__dirname, 'nodeachrome.sock');
+if (process.argv.length < 3) {
+  process.stderr.write(`usage: ${process.argv[0]} [-e code | command]\n`);
+  process.exit(1);
+}
 
+const SOCKET_PATH = path.join(__dirname, 'nodeachrome.sock');
 const client = net.connect(SOCKET_PATH);
 
-// TODO: recognize -e flag to evaluate code
-const code = process.argv[2] || '1+2';
-const cmd = {fromUnix: true, args: ['eval', code]};
+let cmd;
+
+if (process.argv[2] === '-e') {
+  const code = process.argv[3] || '1+2';
+  cmd = {fromUnix: true, args: ['eval', code]};
+} else {
+  cmd = {fromUnix: true, args: process.argv.slice(2)};
+}
 
 const Readable = require('stream').Readable;
 const rs = new Readable({objectMode: true});

--- a/host/cli.js
+++ b/host/cli.js
@@ -1,0 +1,25 @@
+#!/Users/admin/.nvm/versions/node/v6.0.0/bin/node
+'use strict';
+
+// Unix command-line interface to talk to native host
+
+const net = require('net');
+const path = require('path');
+const nativeMessage = require('chrome-native-messaging');
+
+const SOCKET_PATH = path.join(__dirname, 'nodeachrome.sock');
+
+const client = net.connect(SOCKET_PATH);
+
+// TODO: recognize -e flag to evaluate code
+const code = process.argv[2] || '1+2';
+const cmd = {method: 'eval', code};
+
+const Readable = require('stream').Readable;
+const rs = new Readable({objectMode: true});
+rs.push(cmd);
+rs.push(null);
+
+rs
+.pipe(new nativeMessage.Output())
+.pipe(client);

--- a/host/cli.js
+++ b/host/cli.js
@@ -13,7 +13,7 @@ const client = net.connect(SOCKET_PATH);
 
 // TODO: recognize -e flag to evaluate code
 const code = process.argv[2] || '1+2';
-const cmd = {method: 'eval', code};
+const cmd = {fromUnix: true, args: ['eval', code]};
 
 const Readable = require('stream').Readable;
 const rs = new Readable({objectMode: true});
@@ -24,7 +24,7 @@ const Writable = require('stream').Writable;
 const ws = new Writable({objectMode: true});
 ws._write = (chunk, encoding, cb) => {
   console.log('writable received',chunk,encoding);
-  // TODO: wait for this
+  // TODO: get data back
 };
 
 rs

--- a/host/cli.js
+++ b/host/cli.js
@@ -20,6 +20,15 @@ const rs = new Readable({objectMode: true});
 rs.push(cmd);
 rs.push(null);
 
+const Writable = require('stream').Writable;
+const ws = new Writable({objectMode: true});
+ws._write = (chunk, encoding, cb) => {
+  console.log('writable received',chunk,encoding);
+  // TODO: wait for this
+};
+
 rs
 .pipe(new nativeMessage.Output())
-.pipe(client);
+.pipe(client)
+.pipe(new nativeMessage.Input())
+.pipe(ws);

--- a/host/host.js
+++ b/host/host.js
@@ -1,4 +1,4 @@
-#!/Users/admin/.nvm/versions/node/v4.2.4/bin/node
+#!/Users/admin/.nvm/versions/node/v6.0.0/bin/node
 // ^ full path to node must be specified above, edit for your system. may also try:
 // #!/usr/local/bin/node
 
@@ -58,8 +58,9 @@ const unixServer = net.createServer((client) => {
   client
   .pipe(new nativeMessage.Input())
   .pipe(new nativeMessage.Transform((msg, push, done) => {
+    console.log('got msg',msg);
     // TODO: add useful commands
-    push({response: 'hi'});
+    push({response: msg});
     done();
   }))
   .pipe(new nativeMessage.Output())

--- a/host/host.js
+++ b/host/host.js
@@ -108,6 +108,8 @@ function messageHandler(msg, push, done) {
   if (method === 'echo') {
     push(msg);
     done();
+  } else if (method === 'fs._ping') {
+    cb(null, {});
   } else if (method === 'fs.access') {
     const path = fixpath(params[0]);
     if (params.length < 2) {


### PR DESCRIPTION
https://github.com/deathcap/nodeachrome/issues/4 Native command-line interface via host

Uses a Unix domain socket to connect to the native host, which then sends messages to the browser

Example usage:

./host/cli.js '1+2'

spawns a new process in Nodeachrome, runs bin/eval.js to eval() 1+2
