### PR TITLE
Unix command-line tool feedback, pipe stdout userland->kernel->host->cli tool

### DIFF
--- a/app/kernel/native.js
+++ b/app/kernel/native.js
@@ -18,7 +18,7 @@ function disconnected(e) {
 function recvIncoming(msg) {
   //console.log('received incoming native msg:',msg);
   if (msg.fromUnix) { // unsolicited request from Unix, not a reply
-    new Process().exec(msg.args);
+    new Process().exec(msg.args, undefined, {stdout: msg.unixID});
     return;
   }
 

--- a/app/kernel/native.js
+++ b/app/kernel/native.js
@@ -34,7 +34,7 @@ function connectPort() {
 }
 
 // Send message using Google Chrome Native Messaging API to a native code host
-function sendNative(method, params, msgID, pid) {
+function sendNative(method, params, msgID, pid) { // TODO: change to take msg, but encode msg.params?
 
   const paramsEncoded = [];
   for (let i = 0; i < params.length; ++i) {
@@ -77,3 +77,6 @@ window.addEventListener('message', (event) => {
   }
 });
 
+module.exports = {
+  sendNative,
+};

--- a/app/kernel/scheduler.js
+++ b/app/kernel/scheduler.js
@@ -167,7 +167,7 @@ window.addEventListener('message', (event) => {
     // Forward redirected stream to native
     const sendNative = require('./native').sendNative;
     sendNative('unix.stdout', [event.data.toUnix, sourceProcess.pid, event.data.output],
-        -1, -1); // TODO: no msgID, pid
+        -1, sourceProcess.pid); // msgID -1 is no callback, since this native call was unsolicited (sent from kernel not userland)
   }
 });
 

--- a/app/kernel/scheduler.js
+++ b/app/kernel/scheduler.js
@@ -164,7 +164,10 @@ window.addEventListener('message', (event) => {
   } else if (event.data.cmd === 'stdout') {
     const sourceProcess = Process.getFromSource(event.source);
 
-    // TODO: send toUnix
+    // Forward redirected stream to native
+    const sendNative = require('./native').sendNative;
+    sendNative('unix.stdout', [event.data.toUnix, sourceProcess.pid, event.data.output],
+        -1, -1); // TODO: no msgID, pid
   }
 });
 

--- a/app/kernel/scheduler.js
+++ b/app/kernel/scheduler.js
@@ -39,7 +39,7 @@ class Process {
   }
 
   // Execute code with arguments and environment, like Unix fork/exec or posix_spawn/system
-  exec(argv, env) {
+  exec(argv, env, redirects) {
     console.log(`Process exec ${this.pid}, argv ${JSON.stringify(argv)}, env ${JSON.stringify(env)}`);
 
     if (!env) env = global.ENV; // inherit from kernel TODO: per-process inheritance, forking
@@ -55,7 +55,7 @@ class Process {
 
       sources.set(this.iframe.contentWindow, this);
 
-      this.iframe.contentWindow.postMessage({cmd: '_start', pid: this.pid, argv: this.argv, env: this.env}, '*');
+      this.iframe.contentWindow.postMessage({cmd: '_start', pid: this.pid, argv: this.argv, env: this.env, redirects}, '*');
       this.state = 'ready'; // ready until process confirms it started by posting reply back to _start: 'started'
     });
     // TODO: add path, to require and/or readFile to execute and run
@@ -161,6 +161,10 @@ window.addEventListener('message', (event) => {
     const sourceProcess = Process.getFromSource(event.source);
 
     sourceProcess.title = event.data.title;
+  } else if (event.data.cmd === 'stdout') {
+    const sourceProcess = Process.getFromSource(event.source);
+
+    // TODO: send toUnix
   }
 });
 

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,8 @@
     "browserify": "^13.0.0",
     "npm": "deathcap/npm#static-require",
     "npm-registry-client": "deathcap/npm-registry-client#browserify",
-    "shellasync": "^2.1.0"
+    "shellasync": "^2.1.0",
+    "tee": "^0.2.0"
   },
   "license": "MIT"
 }

--- a/app/userland/_start.js
+++ b/app/userland/_start.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// Process initialization
+
+// Save kernel data for syscall
+let kernel = {
+  source: null,
+  origin: null,
+};
+
+// our sandbox identifier, who we are. global _per sandbox_ - basically like a Unix pid
+// TODO: replace with getter/setter defineProperty, since not actually supposed to set it, per the API
+process.pid = null;
+
+window.addEventListener('message', (event) => {
+  if (event.data.cmd === '_start') {
+    // Start a new sandbox (like _start in C or Unix, runs before kernel)
+
+    // save for sending messages back to kernel thread later
+    kernel.source = event.source;
+    kernel.origin = event.origin;
+    process.pid = event.data.pid;
+    process.argv = ['/bin/node'].concat(event.data.argv || ['a.out']); // [0]=always node, [1]=script name, [2]=args
+    process.title = process.argv[1];
+    process.env = event.data.env || {};
+
+    console.log('sandbox received _start:',event.data);
+
+    if (event.data.redirects && event.data.redirects.stdout) {
+
+      const Writable = require('stream').Writable;
+      class RedirStdout extends Writable {
+        constructor(toUnix) {
+          super();
+          this.toUnix = toUnix;
+        }
+
+        _write(chunks, encoding, cb) {
+          const output = chunks.toString ? chunks.toString() : chunks;
+          console.log('REDIR STDOUT', this.toUnix, output);
+          const syscall = require('./syscall').syscall;
+
+          syscall({cmd: 'stdout', toUnix: this.toUnix, output});
+
+          process.nextTick(cb);
+        }
+      }
+      process.stdout = new RedirStdout(event.data.redirects.stdout);
+      // TODO: also see to BrowserStdout?
+    }
+
+    process.stdout.write(`\nStarted pid=${process.pid}, argv=${JSON.stringify(process.argv)}, env=${JSON.stringify(process.env)}\n`);
+
+    event.source.postMessage({cmd: 'started'}, event.origin);
+
+    // TODO: dynamic requires
+    // This is what we can do now with browserify
+    let commands = {
+      init: () => require('./bin/init'),
+      npm: () => require('./bin/npm'),
+      browserify: () => require('./bin/browserify'),
+      ls: () => require('./bin/ls'),
+      eval: () => require('./bin/eval'),
+      false: () => require('./bin/false'),
+      true: () => require('./bin/true'),
+      echo: () => require('./bin/echo'),
+    };
+
+    if (commands[process.argv[1]]) {
+      commands[process.argv[1]]();
+    }
+  }
+});
+
+module.exports = {
+  kernel,
+};

--- a/app/userland/bin/echo.js
+++ b/app/userland/bin/echo.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// TODO: support -n, \c? see echo(1)
+
+const text = process.argv.slice(2).join(' ') + '\n';
+
+// TODO: write each arg individually? writev? that's what https://svnweb.freebsd.org/base/head/bin/echo/echo.c?revision=181269&view=markup#l127 does
+process.stdout.write(text);
+
+// TODO: exit with error if write error?

--- a/app/userland/bin/false.js
+++ b/app/userland/bin/false.js
@@ -1,0 +1,3 @@
+'use strict';
+
+process.exit(1);

--- a/app/userland/bin/true.js
+++ b/app/userland/bin/true.js
@@ -1,0 +1,3 @@
+'use strict';
+
+process.exit(0);

--- a/app/userland/native-proxy.js
+++ b/app/userland/native-proxy.js
@@ -16,6 +16,11 @@ window.addEventListener('message', (event) => {
 });
 
 function handleIncoming(msg) {
+  if (msg.msgID === -1) {
+    // special case: no callback
+    return;
+  }
+
   const cb = callbacks.get(msg.msgID);
   if (!cb) {
     throw new Error(`received native host message with unexpected id: ${msg.msgID} in ${JSON.stringify(msg)}`);

--- a/app/userland/syscall.js
+++ b/app/userland/syscall.js
@@ -35,6 +35,8 @@ window.addEventListener('message', (event) => {
       browserify: () => require('./bin/browserify'),
       ls: () => require('./bin/ls'),
       eval: () => require('./bin/eval'),
+      false: () => require('./bin/false'),
+      true: () => require('./bin/true'),
     };
 
     if (commands[process.argv[1]]) {

--- a/app/userland/syscall.js
+++ b/app/userland/syscall.js
@@ -3,73 +3,10 @@
 // "System calls", userland -> kernel
 // Code below runs within an individual sandbox, talks back to 'kernel' (= main thread), in multi.js
 
-let kernelSource = null;
-let kernelOrigin = null;
-
-// our sandbox identifier, who we are. global _per sandbox_ - basically like a Unix pid
-// TODO: replace with getter/setter defineProperty, since not actually supposed to set it, per the API
-process.pid = null;
-
-window.addEventListener('message', (event) => {
-  if (event.data.cmd === '_start') {
-    // Start a new sandbox (like _start in C or Unix, runs before kernel)
-
-    // save for sending messages back to kernel thread later
-    kernelSource = event.source;
-    kernelOrigin = event.origin;
-    process.pid = event.data.pid;
-    process.argv = ['/bin/node'].concat(event.data.argv || ['a.out']); // [0]=always node, [1]=script name, [2]=args
-    process.title = process.argv[1];
-    process.env = event.data.env || {};
-
-    console.log('sandbox received _start:',event.data);
-
-    if (event.data.redirects && event.data.redirects.stdout) {
-
-      const Writable = require('stream').Writable;
-      class RedirStdout extends Writable {
-        constructor(toUnix) {
-          super();
-          this.toUnix = toUnix;
-        }
-
-        _write(chunks, encoding, cb) {
-          const output = chunks.toString ? chunks.toString() : chunks;
-          console.log('REDIR STDOUT', this.toUnix, output);
-          syscall({cmd: 'stdout', toUnix: this.toUnix, output});
-
-          process.nextTick(cb);
-        }
-      }
-      process.stdout = new RedirStdout(event.data.redirects.stdout);
-      // TODO: also see to BrowserStdout?
-    }
-
-    process.stdout.write(`\nStarted pid=${process.pid}, argv=${JSON.stringify(process.argv)}, env=${JSON.stringify(process.env)}\n`);
-
-    event.source.postMessage({cmd: 'started'}, event.origin);
-
-    // TODO: dynamic requires
-    // This is what we can do now with browserify
-    let commands = {
-      init: () => require('./bin/init'),
-      npm: () => require('./bin/npm'),
-      browserify: () => require('./bin/browserify'),
-      ls: () => require('./bin/ls'),
-      eval: () => require('./bin/eval'),
-      false: () => require('./bin/false'),
-      true: () => require('./bin/true'),
-      echo: () => require('./bin/echo'),
-    };
-
-    if (commands[process.argv[1]]) {
-      commands[process.argv[1]]();
-    }
-  }
-});
+const kernel = require('./_start').kernel; // get kernel origin/source on startup
 
 function syscall(msg) {
-  kernelSource.postMessage(msg, kernelOrigin);
+  kernel.source.postMessage(msg, kernel.origin);
 }
 
 module.exports = {

--- a/app/userland/syscall.js
+++ b/app/userland/syscall.js
@@ -36,7 +36,6 @@ window.addEventListener('message', (event) => {
         _write(chunks, encoding, cb) {
           const output = chunks.toString ? chunks.toString() : chunks;
           console.log('REDIR STDOUT', this.toUnix, output);
-          debugger;
           syscall({cmd: 'stdout', toUnix: this.toUnix, output});
 
           process.nextTick(cb);

--- a/app/userland/syscall.js
+++ b/app/userland/syscall.js
@@ -42,6 +42,7 @@ window.addEventListener('message', (event) => {
         }
       }
       process.stdout = new RedirStdout(event.data.redirects.stdout);
+      // TODO: also see to BrowserStdout?
     }
 
     process.stdout.write(`\nStarted pid=${process.pid}, argv=${JSON.stringify(process.argv)}, env=${JSON.stringify(process.env)}\n`);

--- a/app/userland/syscall.js
+++ b/app/userland/syscall.js
@@ -37,6 +37,7 @@ window.addEventListener('message', (event) => {
       eval: () => require('./bin/eval'),
       false: () => require('./bin/false'),
       true: () => require('./bin/true'),
+      echo: () => require('./bin/echo'),
     };
 
     if (commands[process.argv[1]]) {

--- a/host/cli.js
+++ b/host/cli.js
@@ -26,8 +26,18 @@ if (process.argv[2] === '-e') {
 
 const Readable = require('stream').Readable;
 const rs = new Readable({objectMode: true});
-rs.push(cmd);
-rs.push(null);
+let sentCmd = false;
+rs._read = (size) => {
+  if (!sentCmd) {
+    rs.push(cmd);
+    sentCmd = true;
+    return;
+  }
+
+  //rs.push(null);
+  // keep the connection open
+  //rs.push(null);
+};
 
 const Writable = require('stream').Writable;
 const ws = new Writable({objectMode: true});
@@ -39,5 +49,9 @@ ws._write = (chunk, encoding, cb) => {
 rs
 .pipe(new nativeMessage.Output())
 .pipe(client)
-.pipe(new nativeMessage.Input())
-.pipe(ws);
+
+client.on('readable', () => {
+  console.log('client is readable');
+  console.log('read=',client.read().toString());
+  //client.pipe(new nativeMessage.Input()).pipe(ws);
+});

--- a/host/cli.js
+++ b/host/cli.js
@@ -53,7 +53,7 @@ ws._write = (msg, encoding, cb) => {
   if (msg.cmd === 'stdout') {
     process.stdout.write(msg.output);
   } else if (msg.cmd === 'ack') {
-    console.log('Host received',msg);
+    //console.log('Host received',msg);
   } else {
     console.log('Unknown message:',msg);
   }

--- a/host/cli.js
+++ b/host/cli.js
@@ -53,6 +53,7 @@ rs
 
 client.on('readable', () => {
   console.log('client is readable');
-  console.log('read=',client.read().toString());
+  const msg = client.read();
+  if (msg) console.log('read=', msg.toString());
   //client.pipe(new nativeMessage.Input()).pipe(ws);
 });

--- a/host/cli.js
+++ b/host/cli.js
@@ -52,8 +52,29 @@ rs
 .pipe(client)
 
 client.on('readable', () => {
-  console.log('client is readable');
-  const msg = client.read();
-  if (msg) console.log('read=', msg.toString());
+  //console.log('client is readable');
+  const data = client.read();
+
+  if (data) {
+    // Decode the buffer to JSON
+    //console.log('read=', data.toString());
+
+    const rs = new Readable;
+    const ws = new Writable({objectMode: true});
+    ws._write = (msg, encoding, cb) => {
+      //console.log('msg',msg);
+
+      if (msg.cmd === 'stdout') {
+        process.stdout.write(msg.output);
+      } else if (msg.cmd === 'ack') {
+        console.log('Host received',msg);
+      } else {
+        console.log('Unknown message:',msg);
+      }
+    };
+    rs.push(data);
+    rs.push(null);
+    rs.pipe(new nativeMessage.Input()).pipe(ws);
+  }
   //client.pipe(new nativeMessage.Input()).pipe(ws);
 });

--- a/host/cli.js
+++ b/host/cli.js
@@ -12,7 +12,7 @@ if (process.argv.length < 3) {
   process.exit(1);
 }
 
-const SOCKET_PATH = path.join(__dirname, 'nodeachrome.sock');
+const SOCKET_PATH = path.join(__dirname, 'sock');
 const client = net.connect(SOCKET_PATH);
 
 let cmd;

--- a/host/cli.js
+++ b/host/cli.js
@@ -41,40 +41,84 @@ rs._read = (size) => {
 };
 
 const Writable = require('stream').Writable;
-const ws = new Writable({objectMode: true});
-ws._write = (chunk, encoding, cb) => {
-  console.log('writable received',chunk,encoding);
-  // TODO: get data back
-};
 
 rs
 .pipe(new nativeMessage.Output())
-.pipe(client)
+.pipe(client);
 
+const ws = new Writable({objectMode: true});
+ws._write = (msg, encoding, cb) => {
+  //console.log('msg',msg);
+
+  if (msg.cmd === 'stdout') {
+    process.stdout.write(msg.output);
+  } else if (msg.cmd === 'ack') {
+    console.log('Host received',msg);
+  } else {
+    console.log('Unknown message:',msg);
+  }
+};
+
+// Decode all messages
+// TODO: find out why I have to do this instead of the straightforward approach in
+// https://github.com/deathcap/nodeachrome/pull/30#issuecomment-217346189
+// which only reads the first message
+const decodeState = {
+  buf: Buffer.alloc(0),
+  push: (msg) => {
+    ws._write(msg, null, () => {});
+  },
+};
 client.on('readable', () => {
   //console.log('client is readable');
-  const data = client.read();
+  const chunk = client.read();
 
-  if (data) {
-    // Decode the buffer to JSON
-    //console.log('read=', data.toString());
-
-    const rs = new Readable;
-    const ws = new Writable({objectMode: true});
-    ws._write = (msg, encoding, cb) => {
-      //console.log('msg',msg);
-
-      if (msg.cmd === 'stdout') {
-        process.stdout.write(msg.output);
-      } else if (msg.cmd === 'ack') {
-        console.log('Host received',msg);
-      } else {
-        console.log('Unknown message:',msg);
-      }
-    };
-    rs.push(data);
-    rs.push(null);
-    rs.pipe(new nativeMessage.Input()).pipe(ws);
+  function done() {
+    //console.log('Done!', decodeState); // done decoding this message
   }
-  //client.pipe(new nativeMessage.Input()).pipe(ws);
+
+  // based on https://github.com/jdiamond/chrome-native-messaging/blob/master/index.js#L38
+  // Input.prototype._transform = function(chunk, encoding, done) {
+ 
+    // Save this chunk.
+    var self = decodeState;
+    self.buf = Buffer.concat([ self.buf, chunk ]);
+
+    function parseBuf() {
+        // Do we have a length yet?
+        if (typeof self.len !== 'number') {
+            // Nope. Do we have enough bytes for the length?
+            if (self.buf.length >= 4) {
+                // Yep. Parse the bytes.
+                self.len = self.buf.readUInt32LE(0);
+                // Remove the length bytes from the buffer.
+                self.buf = self.buf.slice(4);
+            }
+        }
+
+        // Do we have a length yet? (We may have just parsed it.)
+        if (typeof self.len === 'number') {
+            // Yep. Do we have enough bytes for the message?
+            if (self.buf.length >= self.len) {
+                // Yep. Slice off the bytes we need.
+                var message = self.buf.slice(0, self.len);
+                // Remove the bytes for the message from the buffer.
+                self.buf = self.buf.slice(self.len);
+                // Clear the length so we know we need to parse it again.
+                self.len = null;
+                // Parse the message bytes.
+                var obj = JSON.parse(message.toString());
+                // Enqueue it for reading.
+                self.push(obj);
+                // We could have more messages in the buffer so check again.
+                parseBuf();
+            }
+        }
+    }
+
+    // Check for a parsable buffer (both length and message).
+    parseBuf();
+
+    // We're done.
+    done();
 });

--- a/host/cli.js
+++ b/host/cli.js
@@ -17,11 +17,12 @@ const client = net.connect(SOCKET_PATH);
 
 let cmd;
 
+const unixID = process.pid; // unique identifier for host to correlate request/responses
 if (process.argv[2] === '-e') {
   const code = process.argv[3] || '1+2';
-  cmd = {fromUnix: true, args: ['eval', code]};
+  cmd = {fromUnix: true, unixID, args: ['eval', code]};
 } else {
-  cmd = {fromUnix: true, args: process.argv.slice(2)};
+  cmd = {fromUnix: true, unixID, args: process.argv.slice(2)};
 }
 
 const Readable = require('stream').Readable;

--- a/host/host.js
+++ b/host/host.js
@@ -71,8 +71,8 @@ const unixServer = net.createServer((client) => {
       rs.push(null);
       rs.pipe(new nativeMessage.Output()).pipe(process.stdout);
 
-      // TODO: send back response to Unix client, after get back from browser
-      push({response: msg});
+      // Just acknowledge we received this message
+      push({cmd: 'ack', msg});
       //done();
 
       let n = 0;

--- a/host/host.js
+++ b/host/host.js
@@ -55,12 +55,16 @@ process.stdin
   .pipe(process.stdout);
 
 // Unix command-line client talks to us on Unix domain socket
+const unixClients = new Map();
 const unixServer = net.createServer((client) => {
   client.on('readable', () => {
     client
     .pipe(new nativeMessage.Input())
     .pipe(new nativeMessage.Transform((msg, push, done) => {
       console.error('unix got',msg);
+
+      unixClients.set(msg.unixID, {msg, push, done});
+
       // Forward the message to the browser (over stdout)
       const rs = new Readable({objectMode: true});
       rs.push(msg);

--- a/host/host.js
+++ b/host/host.js
@@ -293,11 +293,15 @@ function messageHandler(msg, push, done) {
     const fromPid = params[1];
     const output = params[2];
 
-    console.log('received unix.stdout',params);
+    console.error('received unix.stdout',params);
     const unixClient = unixClients.get(toUnix);
+    if (!unixClient) {
+      cb(new Error(`no such Unix client: ${toUnix}`));
+      return;
+    }
 
     unixClient.push({cmd: 'stdout', output, fromPid});
-
+    cb(null);
   } else {
     push({error: {
       code: -32601, // defined in http://www.jsonrpc.org/specification#response_object

--- a/host/host.js
+++ b/host/host.js
@@ -288,6 +288,16 @@ function messageHandler(msg, push, done) {
       });
       done();
     });
+  } else if (method === 'unix.stdout') {
+    const toUnix = params[0];
+    const fromPid = params[1];
+    const output = params[2];
+
+    console.log('received unix.stdout',params);
+    const unixClient = unixClients.get(toUnix);
+
+    unixClient.push({cmd: 'stdout', output, fromPid});
+
   } else {
     push({error: {
       code: -32601, // defined in http://www.jsonrpc.org/specification#response_object

--- a/host/host.js
+++ b/host/host.js
@@ -75,11 +75,13 @@ const unixServer = net.createServer((client) => {
       push({cmd: 'ack', msg});
       //done();
 
+      /* for debugging throughput
       let n = 0;
       setInterval(() => {
         push({counter: n++});
         //done();
       }, 1000);
+      */
     }))
     .pipe(new nativeMessage.Output())
     .pipe(client);

--- a/host/host.js
+++ b/host/host.js
@@ -21,7 +21,7 @@ const path = require('path');
 const Readable = require('stream').Readable;
 const nativeMessage = require('chrome-native-messaging');
 
-const SOCKET_PATH = path.join(__dirname, 'nodeachrome.sock');
+const SOCKET_PATH = path.join(__dirname, 'sock');
 
 // Prepend all paths with this filesystem root
 const ROOT = path.join(__dirname, '../sandbox');
@@ -72,7 +72,11 @@ const unixServer = net.createServer((client) => {
   .pipe(new nativeMessage.Output())
   .pipe(client);
 });
-fs.unlinkSync(SOCKET_PATH);
+try {
+  fs.unlinkSync(SOCKET_PATH);
+} catch (e) {
+  // ignore
+}
 unixServer.listen(SOCKET_PATH);
 
 function encodeResult(err, data, msgID, pid) {


### PR DESCRIPTION
- [x] stdout redirect
- [x] fix broken decoding on cli end
- [x] refactor stdout.js to include RedirStdout as well, assign process.stdout deterministically
- [x] tee BrowserStdout / RedirStdout (Unix redirect stdout)

When invoked from the cli interface, pipe the process.stdout stream from the browser process, to the kernel, to the native host, back to the Unix command-line tool:

```
host $ ./cli.js npm view ucfirst
Started pid=20, argv=["/bin/node","npm","view","ucfirst"], env={"TERM":"xterm-256color","SHELL":"/bin/sh","USER":"user","LOGNAME":"user","PATH":"~/.bin/:/usr/bin/:/bin:/usr/sbin:/sbin:/usr/local/bin","PWD":"/","HOME":"/home"}

{ name: 'ucfirst',
  description: 'uppercase first character of a string',
  'dist-tags': { latest: '1.0.0' },
  versions: [ '0.0.1', '1.0.0' ],
  maintainers: [ 'deathcap <deathcap@gmx.co.uk>' ],
  time: 
   { modified: '2015-07-09T02:59:54.506Z',
     created: '2014-03-10T05:26:24.181Z',
     '0.0.1': '2014-03-10T05:26:25.588Z',
     '1.0.0': '2015-07-09T02:58:48.068Z' },
  readmeFilename: 'README.md',
  keywords: [ 'ucfirst', 'uppercase', 'characters', 'text' ],
  repository: { type: 'git', url: 'git@github.com:deathcap/ucfirst.git' },
  bugs: { url: 'https://github.com/deathcap/ucfirst/issues' },
  license: 'MIT',
  homepage: 'https://github.com/deathcap/ucfirst',
  version: '1.0.0',
  main: 'ucfirst.js',
  files: [ 'ucfirst.js' ],
  scripts: { test: 'node test.js' },
  devDependencies: { tape: '^4.0.0' },
  gitHead: 'b827bc1e0a08a663c75c7258480deece761216d6',
  dist: 
   { shasum: '4e105b6448d05e264ecec435e0b919363c5f2f2f',
     tarball: 'https://registry.npmjs.org/ucfirst/-/ucfirst-1.0.0.tgz' },
  directories: {} }
```

relevant: https://github.com/deathcap/nodeachrome/issues/21 child_process API: stdio
